### PR TITLE
Fixed a bug: the fill[] arrays were of insufficient length.

### DIFF
--- a/sha256.c
+++ b/sha256.c
@@ -136,8 +136,9 @@ void sha256_process(sha256_ctx *ctx, const uint8_t *data, size_t length)
 
 void sha256_final(sha256_ctx *ctx, uint8_t out [32])
 {
-	const char fill [56] = {
+	const char fill [64] = {
 		0x80, 0, 0, 0, 0, 0, 0, 0,
+		   0, 0, 0, 0, 0, 0, 0, 0,
 		   0, 0, 0, 0, 0, 0, 0, 0,
 		   0, 0, 0, 0, 0, 0, 0, 0,
 		   0, 0, 0, 0, 0, 0, 0, 0,

--- a/sha512.c
+++ b/sha512.c
@@ -152,8 +152,9 @@ void sha512_process(sha512_ctx *ctx, const uint8_t *data, size_t length)
 
 void sha512_final(sha512_ctx *ctx, uint8_t out [64])
 {
-	const char fill [112] = {
+	const char fill [128] = {
 		0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,


### PR DESCRIPTION
The fill[] arrays are of insufficient length both in sha256.c and in sha512.c files.

Here is an example to reproduce the bug for SHA512:

uint8_t zero[112] = { 0 };
uint8_t hash[64];
sha512_simple(zero, sizeof(zero), hash);

As the result the hash[] is e8c4a0f846317444f4b3153d050f9ba10c5ccbf1fa72a320c7e74f8a97327db196b9703d664f08093f04786edcb201b076a67c0b523a8705641f0dc11b1fc9e4.

But the right hash is a different one:
dd if=/dev/zero of=zero112 bs=1 count=112 ; sha512sum zero112
2be2e788c8a8adeaa9c89a7f78904cacea6e39297d75e0573a73c756234534d6627ab4156b48a6657b29ab8beb73334040ad39ead81446bb09c70704ec707952

This fix makes the C-SHA2 library to produce the right hash.